### PR TITLE
jupyter/base-notebook version bump

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jupyter/base-notebook:notebook-6.4.2
+FROM jupyter/base-notebook:notebook-6.4.6
 
 # Add a "USER root" statement followed by RUN statements to install system packages using apt-get,
 # change file permissions, etc.


### PR DESCRIPTION
A quick version bump - it's a minor version bump so it should be okay. 

In version 6.4.2 `NOTEBOOK_ARGS` is broken (https://github.com/jupyter/docker-stacks/issues/1034), and it was fixed here: https://github.com/jupyter/docker-stacks/pull/1531