### PR TITLE
ci: switching container registry + overral refactor

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -1,4 +1,4 @@
-name: Build, test, and publish Docker Images
+name: Build, test, and publish Docker images
 
 on:
   pull_request:
@@ -12,38 +12,64 @@ on:
       - "*.md"
       - "LICENSE"
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  LATEST_TAG: latest
+  MAIN_BRANCH: main
+
 jobs:
   build-test-publish:
-    name: Build, test, and publish Docker Images
+    name: Build, test, and publish Docker images
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     if: >
       !contains(github.event.head_commit.message, 'ci skip') &&
       !contains(github.event.pull_request.title, 'ci skip')
     steps:
-      - name: Clone Main Repo
-        uses: actions/checkout@v2
+      - name: Clone main repository
+        uses: actions/checkout@v3
         with:
-          path: main
+          path: ${{ env.MAIN_BRANCH }}
+          fetch-depth: 0
 
-      - name: Set Up Python
-        uses: actions/setup-python@v2
+      - name: Set up Python
+        uses: actions/setup-python@v4
         with:
           python-version: 3.x
+          cache: 'pip'
 
-      - name: Build Docker Image
-        run: make -C main build
-
-      - name: Install Dev Dependencies
+      - name: Test Docker image
         run: |
-          python -m pip install --upgrade pip
-          make -C main test-env
+          make -C main test
+          IMAGE_NAME=${{ env.IMAGE_NAME }}
+          TAG=${{ env.LATEST_TAG }}
 
-      - name: Test Docker Image
-        run: make -C main test
+      - name: Log in to the Container registry
+        if: github.ref == 'refs/heads/${{ env.MAIN_BRANCH }}'
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Publish Docker Image
-        if: github.ref == 'refs/heads/main'
-        run: >
-          make -C main push
-          DOCKERHUB_USERNAME="${{secrets.DOCKERHUB_USERNAME}}"
-          DOCKERHUB_PASSWORD="${{secrets.DOCKERHUB_PASSWORD}}"
+      - name: Extract metadata (tags, labels) for Docker
+        if: github.ref == 'refs/heads/${{ env.MAIN_BRANCH }}'
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=sha,prefix=,suffix=,format=short
+            type=raw,value=${{ env.LATEST_TAG }}
+
+      - name: Build and push Docker image
+        if: github.ref == 'refs/heads/${{ env.MAIN_BRANCH }}'
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Test Docker image
         run: |
-          make -C main test
+          make test
           IMAGE_NAME=${{ env.IMAGE_NAME }}
           TAG=${{ env.LATEST_TAG }}
 

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -29,11 +29,8 @@ jobs:
       !contains(github.event.head_commit.message, 'ci skip') &&
       !contains(github.event.pull_request.title, 'ci skip')
     steps:
-      - name: Clone main repository
+      - name: Checkout repository
         uses: actions/checkout@v3
-        with:
-          path: ${{ env.MAIN_BRANCH }}
-          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -37,6 +37,7 @@ jobs:
         with:
           python-version: 3.x
           cache: 'pip'
+          cache-dependency-path: '**/requirements-test.txt'
 
       - name: Test Docker image
         run: |

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -16,7 +16,6 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
   LATEST_TAG: latest
-  MAIN_BRANCH: main
 
 jobs:
   build-test-publish:
@@ -46,7 +45,7 @@ jobs:
           TAG=${{ env.LATEST_TAG }}
 
       - name: Log in to the Container registry
-        if: github.ref == 'refs/heads/${{ env.MAIN_BRANCH }}'
+        if: github.ref == 'refs/heads/main'
         uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
@@ -54,7 +53,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata (tags, labels) for Docker
-        if: github.ref == 'refs/heads/${{ env.MAIN_BRANCH }}'
+        if: github.ref == 'refs/heads/main'
         id: meta
         uses: docker/metadata-action@v4
         with:
@@ -64,7 +63,7 @@ jobs:
             type=raw,value=${{ env.LATEST_TAG }}
 
       - name: Build and push Docker image
-        if: github.ref == 'refs/heads/${{ env.MAIN_BRANCH }}'
+        if: github.ref == 'refs/heads/main'
         uses: docker/build-push-action@v3
         with:
           context: .

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ docker run -it --rm \
   -p 8888:8888 \
   -e JUPYTER_ENABLE_LAB=yes \
   -e CHOWN_HOME=yes \
-  knonm/kotlin-notebook:latest
+  ghcr.io/knonm/kotlin-notebook:latest
 ```
 
 Then open http://localhost:8888 to try it out.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,7 @@ def docker_client():
 @pytest.fixture(scope='session')
 def image_name():
     """Image name to test"""
-    return 'knonm/kotlin-notebook'
+    return os.environ.get('PYTEST_IMAGE_NAME')
 
 
 class TrackedContainer(object):


### PR DESCRIPTION
- Replaces Docker Hub container registry with Github container registry (`ghcr.io`).
- Docker image publish pipeline (login + build + tags + push) is now being made using Docker Github Actions only:
  - Login: `docker/login-action@v2`
  - Metadata (tags and labels): `docker/metadata-action@v4`
  - Build and push: `docker/build-push-action@v3`
- Overall Makefile refactor.