### PR TITLE
build: set a fixed kotlin kernel version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,6 @@ USER $NB_UID
 
 ENV JUPYTER_ENABLE_LAB=yes
 
-RUN conda install -c jetbrains kotlin-jupyter-kernel
+COPY requirements.txt .
+
+RUN pip install kotlin-jupyter-kernel -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+kotlin-jupyter-kernel==0.11.0.385


### PR DESCRIPTION
- Start using an exact / fixed version for the Kotlin Kernel to prevent automatic updates to the latest version with each release. The goal here is to separate changes unrelated to kernel versions from version updates, thus avoiding unexpected side effects on such changes.

- Enable Dependabot integration for `pip`. From now on, it is going to be easier to track back Docker images to a kernel version.

- Replace `conda` with `pip` and begin using `requirements.txt` to manage the Kotlin Kernel version. This change is necessary to enable integration with Dependabot.